### PR TITLE
Limit redis and redis-namespace versions to fix namespace issue; Update redis.template.yml to show namespacing example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,9 @@ gem 'rails', '~> 7.1.3', '>= 7.1.3.2'
 # Rainbow for text coloring
 gem 'rainbow', '~> 3.0'
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '>= 4.0.1'
+gem 'redis', '~> 4.8' # NOTE: Updating the redis gem to v5 breaks the current redis namespace setup
+# For namespacing the Redis keys used by resque
+gem 'redis-namespace', '~> 1.11'
 # Resque for queued jobs
 gem 'resque', '~> 2.6'
 # Resque for retrying code after errors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,10 +332,7 @@ GEM
     rake (13.1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redis (5.1.0)
-      redis-client (>= 0.17.0)
-    redis-client (0.21.1)
-      connection_pool
+    redis (4.8.1)
     redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.9.0)
@@ -516,7 +513,8 @@ DEPENDENCIES
   puma (~> 6.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   rainbow (~> 3.0)
-  redis (>= 4.0.1)
+  redis (~> 4.8)
+  redis-namespace (~> 1.11)
   resque (~> 2.6)
   retriable (~> 3.1)
   rspec-rails

--- a/config/templates/redis.template.yml
+++ b/config/templates/redis.template.yml
@@ -2,6 +2,7 @@ default: &default
   host: localhost
   port: 6379
   password: null
+  namespace: <%= "#{Rails.application.class.module_parent_name}:#{Rails.env}" %>
 
 development:
   <<: *default


### PR DESCRIPTION
Waiting to merge this until the current queue drains, since we currently have a lot of queued jobs and don't want to change the namespace before they're done.