### PR TITLE
Fix app install

### DIFF
--- a/config/templates/gcp.template.yml
+++ b/config/templates/gcp.template.yml
@@ -7,6 +7,7 @@ development:
   preservation_bucket_name: 'example-dev-bucket'
   local_path_key_map:
     '/digital/preservation/': ''
+  mock_credentials: true
   credentials:
     # Note: The lines below should be a line-for-line copy of what Google provides in a credentials.json key file
     type: 'fill-this-in'


### PR DESCRIPTION
When attempting a clean install of the app, db migration fails with an error thrown by config/initializers/gcp.rb due to invalid credentials.