### PR TITLE
DSM-161: Object Details UI + pagination improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,0 @@
-# Ignore artifacts:
-build
-coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Ignore artifacts:
+build
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "trailingComma": "all",
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true,
-  "printWidth": 100
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/app/s3browser/src/app/provider.tsx
+++ b/app/s3browser/src/app/provider.tsx
@@ -1,11 +1,37 @@
-import { FC, PropsWithChildren, Suspense, useState } from 'react';
+import { FC, PropsWithChildren, ReactNode, Suspense, useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ErrorBoundary } from 'react-error-boundary';
 import Spinner from 'react-bootstrap/Spinner';
 
 import { MainErrorFallback } from '@/components/errors/main';
+import { Notifications } from '@/components/ui/notifications/notifications';
 import { queryConfig } from '@/lib/react-query';
+import { useCurrentUser } from '@/lib/auth';
+
+function AuthLoader({ children }: { children: ReactNode }) {
+  const { data: user, isLoading } = useCurrentUser();
+
+  console.log('AuthLoader - user:', user, 'isLoading:', isLoading);
+
+  // Side effects like modifying window.location should be done in useEffect
+  useEffect(() => {
+    // Added as a safeguard, but Rails should only render React app if user is authenticated
+    if (!isLoading && !user) {
+      window.location.href = '/';
+    }
+  }, [user, isLoading]);
+
+  if (isLoading) {
+    return <div>Loading user...</div>;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
 
 export const AppProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [queryClient] = useState(
@@ -26,7 +52,8 @@ export const AppProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
       <ErrorBoundary FallbackComponent={MainErrorFallback}>
         <QueryClientProvider client={queryClient}>
           {import.meta.env.DEV && <ReactQueryDevtools />}
-          {children}
+          <Notifications />
+          <AuthLoader>{children}</AuthLoader>
         </QueryClientProvider>
       </ErrorBoundary>
     </Suspense>

--- a/app/s3browser/src/app/provider.tsx
+++ b/app/s3browser/src/app/provider.tsx
@@ -12,8 +12,6 @@ import { useCurrentUser } from '@/lib/auth';
 function AuthLoader({ children }: { children: ReactNode }) {
   const { data: user, isLoading } = useCurrentUser();
 
-  console.log('AuthLoader - user:', user, 'isLoading:', isLoading);
-
   // Side effects like modifying window.location should be done in useEffect
   useEffect(() => {
     // Added as a safeguard, but Rails should only render React app if user is authenticated

--- a/app/s3browser/src/app/router.tsx
+++ b/app/s3browser/src/app/router.tsx
@@ -46,7 +46,6 @@ export const createAppRouter = (queryClient: QueryClient) =>
               lazy: () => import('./routes/bucket-contents').then(convert(queryClient)),
             },
             {
-              // * This route will be changed later to be nested under the bucket route
               path: ':bucketName/object-details',
               lazy: () => import('./routes/object-details').then(convert(queryClient)),
             }

--- a/app/s3browser/src/app/router.tsx
+++ b/app/s3browser/src/app/router.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
-import { createBrowserRouter, LoaderFunction, ActionFunction, Route } from 'react-router';
+import { createBrowserRouter, LoaderFunction, ActionFunction } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 import { Spinner } from 'react-bootstrap';
 import MainLayout from '@/components/layouts/main-layout';

--- a/app/s3browser/src/app/router.tsx
+++ b/app/s3browser/src/app/router.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
-import { createBrowserRouter, LoaderFunction, ActionFunction } from 'react-router';
+import { createBrowserRouter, LoaderFunction, ActionFunction, Route } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 import { Spinner } from 'react-bootstrap';
 import MainLayout from '@/components/layouts/main-layout';
+import { RouteErrorFallback } from '@/components/errors/route-error';
 
 interface RouteModule {
   default: React.ComponentType;
@@ -28,6 +29,7 @@ export const createAppRouter = (queryClient: QueryClient) =>
   createBrowserRouter([
     {
       hydrateFallbackElement: <Spinner animation="border" role="status" />,
+      errorElement: <RouteErrorFallback />,
       children: [
         {
           index: true,
@@ -46,10 +48,11 @@ export const createAppRouter = (queryClient: QueryClient) =>
               lazy: () => import('./routes/bucket-contents').then(convert(queryClient)),
             },
             {
-              // * This route will be changed later to be nested under the bucket route
               path: ':bucketName/object-details',
               lazy: () => import('./routes/object-details').then(convert(queryClient)),
-            }
+              // This route uses useSuspenseQuery, so we want to ensure any errors are caught by the route error boundary
+              errorElement: <RouteErrorFallback errorMessage="Error loading object details. Please try again." />,
+            },
           ],
         },
       ],

--- a/app/s3browser/src/app/router.tsx
+++ b/app/s3browser/src/app/router.tsx
@@ -45,13 +45,13 @@ export const createAppRouter = (queryClient: QueryClient) =>
               path: ':bucketName',
               lazy: () => import('./routes/bucket-contents').then(convert(queryClient)),
             },
+            {
+              // * This route will be changed later to be nested under the bucket route
+              path: ':bucketName/object-details',
+              lazy: () => import('./routes/object-details').then(convert(queryClient)),
+            }
           ],
         },
-        {
-          // * This route will be changed later to be nested under the bucket route
-          path: 'object/:bucketName',
-          lazy: () => import('./routes/object-details').then(convert(queryClient)),
-        }
       ],
     },
     {

--- a/app/s3browser/src/app/routes/bucket-contents.tsx
+++ b/app/s3browser/src/app/routes/bucket-contents.tsx
@@ -15,6 +15,8 @@ export const clientLoader = (queryClient: QueryClient) => async ({ params, reque
   const prefix = normalizePrefix(url.searchParams.get('prefix') ?? '');
   const query = getBucketContentsQueryOptions(bucketName, prefix);
 
+  // Our API returns results in ~1-2 seconds for large buckets, so we don't want to 
+  // await this and block the UI. Instead, we let the component handle the loading state.
   queryClient.prefetchQuery(query);
 };
 

--- a/app/s3browser/src/app/routes/bucket-contents.tsx
+++ b/app/s3browser/src/app/routes/bucket-contents.tsx
@@ -1,5 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
-import { LoaderFunctionArgs } from 'react-router';
+import { LoaderFunctionArgs, useParams } from 'react-router';
 import { getBucketContentsQueryOptions } from '@/features/file-browser/api/get-bucket-contents';
 import BucketContentsTable from '@/features/file-browser/components/bucket-contents-table';
 
@@ -21,7 +21,15 @@ export const clientLoader = (queryClient: QueryClient) => async ({ params, reque
 };
 
 const BucketContentsRoute = () => {
-  return <BucketContentsTable />;
+  const params = useParams();
+  const bucketName = params.bucketName as string;
+
+  return (
+    <>
+      <title>{`Bucket ${bucketName} contents`}</title>
+      <BucketContentsTable />
+    </>
+  );
 };
 
 export default BucketContentsRoute;

--- a/app/s3browser/src/app/routes/buckets.tsx
+++ b/app/s3browser/src/app/routes/buckets.tsx
@@ -9,7 +9,12 @@ export const clientLoader = (queryClient: QueryClient) => async () => {
 };
 
 const BucketsRoute = () => {
-  return <BucketList />;
+  return (
+    <>
+      <title>S3 Buckets</title>
+      <BucketList />
+    </>
+  );
 };
 
 export default BucketsRoute;

--- a/app/s3browser/src/app/routes/not-found.tsx
+++ b/app/s3browser/src/app/routes/not-found.tsx
@@ -1,9 +1,12 @@
 const NotFoundRoute = () => {
   return (
-    <div className="mt-2 d-flex flex-column align-items-center text-center">
-      <h1>404 - Not Found</h1>
-      <p>Sorry, the page you are looking for does not exist.</p>
-    </div>
+    <>
+      <title>404 Not Found</title>
+      <div className="mt-2 d-flex flex-column align-items-center text-center">
+        <h1>404 - Not Found</h1>
+        <p>Sorry, the page you are looking for does not exist.</p>
+      </div>
+    </>
   );
 };
 

--- a/app/s3browser/src/app/routes/object-details.tsx
+++ b/app/s3browser/src/app/routes/object-details.tsx
@@ -19,7 +19,12 @@ const ObjectDetailsRoute = () => {
   const key = searchParams.get('prefix') ?? '';
   const query = useObjectDetailsSuspenseQuery({ bucket: bucketName, key });
 
-  return <ObjectDetailDisplay objectDetails={query.data} />;
+  return (
+    <>
+      <title>{`Object Details - ${key}`}</title>
+      <ObjectDetailDisplay objectDetails={query.data} />
+    </>
+  );
 };
 
 export default ObjectDetailsRoute;

--- a/app/s3browser/src/app/routes/object-details.tsx
+++ b/app/s3browser/src/app/routes/object-details.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs, useParams } from 'react-router';
+import { LoaderFunctionArgs, useParams, useSearchParams } from 'react-router';
 import { QueryClient } from '@tanstack/react-query';
 import { getObjectDetailsQueryOptions, useObjectDetailsSuspenseQuery } from '@/features/file-browser/api/get-object-details';
 import ObjectDetailDisplay from '@/features/file-browser/components/object-detail-display';
@@ -15,8 +15,8 @@ export const clientLoader = (queryClient: QueryClient) => async ({ params, reque
 const ObjectDetailsRoute = () => {
   const params = useParams();
   const bucketName = params.bucketName as string;
-  const url = new URL(window.location.href);
-  const key = url.searchParams.get('prefix') ?? '';
+  const [searchParams] = useSearchParams();
+  const key = searchParams.get('prefix') ?? '';
   const query = useObjectDetailsSuspenseQuery({ bucket: bucketName, key });
 
   return <ObjectDetailDisplay objectDetails={query.data} />;

--- a/app/s3browser/src/app/routes/object-details.tsx
+++ b/app/s3browser/src/app/routes/object-details.tsx
@@ -1,6 +1,7 @@
+import { LoaderFunctionArgs, useParams } from 'react-router';
 import { QueryClient } from '@tanstack/react-query';
-import { getObjectDetailsQueryOptions } from '@/features/file-browser/api/get-object-details';
-import { LoaderFunctionArgs } from 'react-router';
+import { getObjectDetailsQueryOptions, useObjectDetailsSuspenseQuery } from '@/features/file-browser/api/get-object-details';
+import ObjectDetailDisplay from '@/features/file-browser/components/object-detail-display';
 
 export const clientLoader = (queryClient: QueryClient) => async ({ params, request }: LoaderFunctionArgs) => {
   const bucketName = params.bucketName as string;
@@ -12,7 +13,13 @@ export const clientLoader = (queryClient: QueryClient) => async ({ params, reque
 };
 
 const ObjectDetailsRoute = () => {
-  return <div>Object Details</div>;
+  const params = useParams();
+  const bucketName = params.bucketName as string;
+  const url = new URL(window.location.href);
+  const key = url.searchParams.get('prefix') ?? '';
+  const query = useObjectDetailsSuspenseQuery({ bucket: bucketName, key });
+
+  return <ObjectDetailDisplay objectDetails={query.data} />;
 };
 
 export default ObjectDetailsRoute;

--- a/app/s3browser/src/app/routes/object-details.tsx
+++ b/app/s3browser/src/app/routes/object-details.tsx
@@ -1,7 +1,15 @@
 import { QueryClient } from '@tanstack/react-query';
+import { getObjectDetailsQueryOptions } from '@/features/file-browser/api/get-object-details';
+import { LoaderFunctionArgs } from 'react-router';
 
-// TODO
-export const clientLoader = (queryClient: QueryClient) => async () => {};
+export const clientLoader = (queryClient: QueryClient) => async ({ params, request }: LoaderFunctionArgs) => {
+  const bucketName = params.bucketName as string;
+  const url = new URL(request.url);
+  const key = url.searchParams.get('prefix') ?? '';
+  const query = getObjectDetailsQueryOptions(bucketName, key);
+
+  await queryClient.prefetchQuery(query);
+};
 
 const ObjectDetailsRoute = () => {
   return <div>Object Details</div>;

--- a/app/s3browser/src/components/errors/route-error.tsx
+++ b/app/s3browser/src/components/errors/route-error.tsx
@@ -1,0 +1,24 @@
+import { Container } from "react-bootstrap";
+import { useRouteError, isRouteErrorResponse } from "react-router";
+
+type RouteErrorFallbackProps = {
+  errorMessage?: string;
+};
+
+export const RouteErrorFallback: React.FC<RouteErrorFallbackProps> = ({ errorMessage }) => {
+  const error = useRouteError();
+
+  return (
+    <Container className="mt-5 p-0">
+      <h3>Oops, something went wrong</h3>
+      <br />
+      <p>{errorMessage || 'The application encountered an error.'}</p>
+        {isRouteErrorResponse(error) && (
+          <Container>
+            <p>{error.status} {error.statusText}</p>
+            <pre>{JSON.stringify(error.data, null, 2)}</pre>
+          </Container>
+        )}
+    </Container>
+  );
+};

--- a/app/s3browser/src/components/ui/notifications/notification.tsx
+++ b/app/s3browser/src/components/ui/notifications/notification.tsx
@@ -47,7 +47,7 @@ export const Notification = ({
       key={id}
       onClose={() => onDismiss(id)}
       className={`bg-${variant}-subtle border-${variant}`}
-      autohide={type !== "error"} // error toasts require manual dismissal
+      autohide
       delay={5000}
     >
       <Toast.Header

--- a/app/s3browser/src/components/ui/notifications/notification.tsx
+++ b/app/s3browser/src/components/ui/notifications/notification.tsx
@@ -1,0 +1,67 @@
+import { Toast } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCircleCheck,
+  faCircleXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import {
+  faTriangleExclamation,
+  faCircleInfo
+} from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+type NotificationType = "success" | "error" | "warning" | "info";
+
+const VARIANT_MAP: Record<NotificationType, string> = {
+  success: "success",
+  error: "danger",
+  warning: "warning",
+  info: "info",
+};
+
+const ICON_MAP: Record<NotificationType, IconDefinition> = {
+  success: faCircleCheck,
+  error: faCircleXmark,
+  warning: faTriangleExclamation,
+  info: faCircleInfo,
+};
+
+export type NotificationProps = {
+  notification: {
+    id: string;
+    type: NotificationType;
+    title: string;
+    message?: string;
+  };
+  onDismiss: (id: string) => void;
+};
+
+export const Notification = ({
+  notification: { id, type, title, message },
+  onDismiss,
+}: NotificationProps) => {
+  const variant = VARIANT_MAP[type];
+
+  return (
+    <Toast
+      key={id}
+      onClose={() => onDismiss(id)}
+      className={`bg-${variant}-subtle border-${variant}`}
+      autohide={type !== "error"} // error toasts require manual dismissal
+      delay={5000}
+    >
+      <Toast.Header
+        className={`bg-transparent border-${variant} border-opacity-25`}
+      >
+        <FontAwesomeIcon
+          icon={ICON_MAP[type]}
+          className={`me-2 text-${variant}-emphasis`}
+        />
+        <strong className={`me-auto text-${variant}-emphasis`}>{title}</strong>
+      </Toast.Header>
+      {message && (
+        <Toast.Body className="text-body-secondary">{message}</Toast.Body>
+      )}
+    </Toast>
+  );
+};

--- a/app/s3browser/src/components/ui/notifications/notifications.tsx
+++ b/app/s3browser/src/components/ui/notifications/notifications.tsx
@@ -1,0 +1,19 @@
+import { ToastContainer } from "react-bootstrap";
+import { useNotifications } from "@/stores/notifications-store";
+import { Notification } from "./notification";
+
+export const Notifications = () => {
+  const { notifications, dismissNotification } = useNotifications();
+
+  return (
+    <ToastContainer position="top-end" className="p-3">
+      {notifications.map((notification) => (
+        <Notification
+          key={notification.id}
+          notification={notification}
+          onDismiss={dismissNotification}
+        />
+      ))}
+    </ToastContainer>
+  );
+}

--- a/app/s3browser/src/components/ui/table-builder/table-body.tsx
+++ b/app/s3browser/src/components/ui/table-builder/table-body.tsx
@@ -1,0 +1,53 @@
+import { ColumnDef, useReactTable } from '@tanstack/react-table'
+import Spinner from 'react-bootstrap/Spinner';
+import TableRow from './table-row'
+
+type TableBodyProps<T> = {
+  table: ReturnType<typeof useReactTable<T>>;
+  columns: ColumnDef<T>[];
+  isLoading?: boolean;
+}
+
+const TableBody = <T extends object>({
+  table,
+  columns,
+  isLoading,
+}: TableBodyProps<T>) => {
+  if (isLoading) {
+    return (
+      <tbody>
+        <tr>
+          <td colSpan={columns.length} className="text-center py-3">
+            <Spinner animation="border" role="status">
+              <span className="visually-hidden">Loading...</span>
+            </Spinner>
+          </td>
+        </tr>
+      </tbody>
+    );
+  }
+
+  const rows = table.getRowModel().rows;
+
+  if (rows.length === 0) {
+    return (
+      <tbody>
+        <tr>
+          <td colSpan={columns.length} className="text-center py-3">
+            No entries found.
+          </td>
+        </tr>
+      </tbody>
+    );
+  }
+
+  return (
+    <tbody>
+      {rows.map((row) => (
+        <TableRow row={row} key={row.id} />
+      ))}
+    </tbody>
+  );
+};
+
+export default TableBody;

--- a/app/s3browser/src/components/ui/table-builder/table-builder.tsx
+++ b/app/s3browser/src/components/ui/table-builder/table-builder.tsx
@@ -12,8 +12,8 @@ import {
 } from '@tanstack/react-table'
 import { Table as BTable } from 'react-bootstrap'
 import TableHeader from './table-header'
-import TableRow from './table-row'
 import TablePagination from './table-pagination'
+import TableBody from './table-body'
 
 interface TableBuilderProps<T> {
   data: T[]
@@ -80,31 +80,11 @@ function TableBuilder<T extends object>({
             key={headerGroup.id}
             headerGroup={headerGroup} />
         ))}
-        <tbody>
-          {/* TODO: Extract into its own component */}
-          {/* Renders table skeleton rows when loading */}
-          {isLoading ? (
-            Array.from({ length: 20 }).map((_el, i) => (
-              <tr key={`skeleton-${i}`}>
-                {columns.map((_col, colIdx) => (
-                  <td key={colIdx} className="placeholder-glow" aria-hidden="true">
-                    <span className="placeholder col-8" />
-                  </td>
-                ))}
-              </tr>
-            ))
-          ) : table.getRowModel().rows.length === 0 ? (
-            <tr>
-              <td colSpan={columns.length} className="text-center py-3">
-                No entries found.
-              </td>
-            </tr>
-          ) : (
-            table.getRowModel().rows.map((row) => (
-              <TableRow row={row} key={row.id} />
-            ))
-          )}
-        </tbody>
+        <TableBody
+          table={table}
+          columns={columns}
+          isLoading={isLoading}
+        />
       </BTable>
     </>
   )

--- a/app/s3browser/src/components/ui/table-builder/table-builder.tsx
+++ b/app/s3browser/src/components/ui/table-builder/table-builder.tsx
@@ -22,6 +22,7 @@ interface TableBuilderProps<T> {
   pageSize?: number,
   pagination?: PaginationState;
   onPaginationChange?: (updater: Updater<PaginationState>) => void;
+  isLoading?: boolean;
 }
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -35,7 +36,8 @@ function TableBuilder<T extends object>({
   initialSorting = [],
   pageSize = DEFAULT_PAGE_SIZE,
   pagination,
-  onPaginationChange
+  onPaginationChange,
+  isLoading
 }: TableBuilderProps<T>) {
   // You can disable sorting specific columns or specify custom sorting functions in the column definitions
   // Docs: https://tanstack.com/table/latest/docs/api/features/sorting#column-def-options
@@ -79,16 +81,29 @@ function TableBuilder<T extends object>({
             headerGroup={headerGroup} />
         ))}
         <tbody>
-          {table.getRowModel().rows.length === 0 && (
+          {/* TODO: Extract into its own component */}
+          {/* Renders table skeleton rows when loading */}
+          {isLoading ? (
+            Array.from({ length: 20 }).map((_el, i) => (
+              <tr key={`skeleton-${i}`}>
+                {columns.map((_col, colIdx) => (
+                  <td key={colIdx} className="placeholder-glow" aria-hidden="true">
+                    <span className="placeholder col-8" />
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : table.getRowModel().rows.length === 0 ? (
             <tr>
               <td colSpan={columns.length} className="text-center py-3">
                 No entries found.
               </td>
             </tr>
+          ) : (
+            table.getRowModel().rows.map((row) => (
+              <TableRow row={row} key={row.id} />
+            ))
           )}
-          {table.getRowModel().rows.map((row) => (
-            <TableRow row={row} key={row.id} />
-          ))}
         </tbody>
       </BTable>
     </>

--- a/app/s3browser/src/components/ui/table-builder/table-builder.tsx
+++ b/app/s3browser/src/components/ui/table-builder/table-builder.tsx
@@ -8,6 +8,7 @@ import {
   SortingState,
   getPaginationRowModel,
   PaginationState,
+  Updater,
 } from '@tanstack/react-table'
 import { Table as BTable } from 'react-bootstrap'
 import TableHeader from './table-header'
@@ -18,7 +19,9 @@ interface TableBuilderProps<T> {
   data: T[]
   columns: ColumnDef<T>[]
   initialSorting?: SortingState,
-  pageSize?: number
+  pageSize?: number,
+  pagination?: PaginationState;
+  onPaginationChange?: (updater: Updater<PaginationState>) => void;
 }
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -26,14 +29,28 @@ const DEFAULT_PAGE_SIZE = 50;
 // This is a generic table component that can be reused across different data types
 // When using this component, ensure you specify how to render each column in the column definitions
 // Docs: https://tanstack.com/table/latest/docs/guide/column-defs
-function TableBuilder<T extends object>({ data, columns, initialSorting = [], pageSize = DEFAULT_PAGE_SIZE }: TableBuilderProps<T>) {
+function TableBuilder<T extends object>({
+  data,
+  columns,
+  initialSorting = [],
+  pageSize = DEFAULT_PAGE_SIZE,
+  pagination,
+  onPaginationChange
+}: TableBuilderProps<T>) {
   // You can disable sorting specific columns or specify custom sorting functions in the column definitions
   // Docs: https://tanstack.com/table/latest/docs/api/features/sorting#column-def-options
   const [sorting, setSorting] = useState<SortingState>(initialSorting)
-  const [pagination, setPagination] = useState<PaginationState>({
+  const [internalPagination, setInternalPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize,
   })
+
+  // Determine if pagination is controlled externally (via props) or internally (via component state)
+  const isPaginationControlled = pagination !== undefined && onPaginationChange !== undefined;
+  const effectivePagination = isPaginationControlled ? pagination : internalPagination;
+  const effectiveOnPaginationChange = isPaginationControlled
+    ? onPaginationChange
+    : setInternalPagination
 
   const table = useReactTable<T>({
     data,
@@ -41,11 +58,11 @@ function TableBuilder<T extends object>({ data, columns, initialSorting = [], pa
     getCoreRowModel: getCoreRowModel(),
     state: {
       sorting,
-      pagination
+      pagination: effectivePagination
     },
     getSortedRowModel: getSortedRowModel(),
     onSortingChange: setSorting,
-    onPaginationChange: setPagination,
+    onPaginationChange: effectiveOnPaginationChange,
     getPaginationRowModel: getPaginationRowModel(),
   })
 

--- a/app/s3browser/src/components/ui/table-builder/table-header.tsx
+++ b/app/s3browser/src/components/ui/table-builder/table-header.tsx
@@ -7,7 +7,6 @@ interface TableHeaderProps<T> {
 }
 
 function TableHeader<T>({ headerGroup }: TableHeaderProps<T>) {
-  // TODO: Make the currently active sorting state more visually distinct (more saturated color) to improve UX
   const renderSortingIcon = (sortDirection: 'asc' | 'desc' | null) => {
     const sharedClassNames = 'ms-2 flex-shrink-0 mt-1'
 

--- a/app/s3browser/src/components/ui/table-builder/table-pagination.tsx
+++ b/app/s3browser/src/components/ui/table-builder/table-pagination.tsx
@@ -9,6 +9,8 @@ interface TablePaginationProps<T> {
 function TablePagination<T>({ table }: TablePaginationProps<T>) {
   const { pageIndex } = table.getState().pagination
   const pageCount = table.getPageCount()
+  const startRow = pageIndex * table.getState().pagination.pageSize + 1
+  const endRow = Math.min((pageIndex + 1) * table.getState().pagination.pageSize, table.getFilteredRowModel().rows.length)
 
   return (
     <Pagination className="mt-2">
@@ -33,7 +35,7 @@ function TablePagination<T>({ table }: TablePaginationProps<T>) {
         disabled={!table.getCanNextPage()}
       />
       <div className="d-flex align-items-center p-2">
-        Showing {table.getPaginationRowModel().rows.length} {pageCount > 1 && `of ${table.getFilteredRowModel().rows.length}`} items
+        Showing {startRow}-{endRow} of {table.getFilteredRowModel().rows.length}
       </div>
     </Pagination>
   )

--- a/app/s3browser/src/features/file-browser/api/get-bucket-contents.ts
+++ b/app/s3browser/src/features/file-browser/api/get-bucket-contents.ts
@@ -31,7 +31,6 @@ export const getBucketContentsQueryOptions = (bucket: string, prefix: string) =>
   });
 };
 
-
 export const useBucketContentsQuery = ({ bucket, prefix, queryConfig }: UseBucketContentsOptions) => {
   return useQuery({
     ...getBucketContentsQueryOptions(bucket, prefix),

--- a/app/s3browser/src/features/file-browser/api/get-object-details.ts
+++ b/app/s3browser/src/features/file-browser/api/get-object-details.ts
@@ -1,0 +1,40 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { BucketContentsResponse } from '@/types/api';
+import { api } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+
+const getObjectDetails = (
+  bucket: string,
+  key: string,
+): Promise<BucketContentsResponse> => {
+  const params = new URLSearchParams();
+  if (key) {
+    params.set('key', key);
+  }
+
+  const query = params.toString();
+  const endpoint = `/buckets/${bucket}/object${query ? `?${query}` : ''}`;
+
+  return api.get<BucketContentsResponse>(endpoint);
+};
+
+type UseObjectDetailsOptions = {
+  bucket: string;
+  key: string;
+  queryConfig?: QueryConfig<typeof getObjectDetailsQueryOptions>;
+};
+
+export const getObjectDetailsQueryOptions = (bucket: string, key: string) => {
+  return queryOptions({
+    queryKey: ['object-details', bucket, key],
+    queryFn: () => getObjectDetails(bucket, key),
+  });
+};
+
+
+export const useObjectDetailsSuspenseQuery = ({ bucket, key, queryConfig }: UseObjectDetailsOptions) => {
+  return useSuspenseQuery({
+    ...getObjectDetailsQueryOptions(bucket, key),
+    ...queryConfig,
+  });
+};

--- a/app/s3browser/src/features/file-browser/api/get-object-details.ts
+++ b/app/s3browser/src/features/file-browser/api/get-object-details.ts
@@ -1,12 +1,12 @@
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
-import { BucketContentsResponse } from '@/types/api';
+import { ObjectDetails } from '@/types/api';
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
 
 const getObjectDetails = (
   bucket: string,
   key: string,
-): Promise<BucketContentsResponse> => {
+): Promise<ObjectDetails> => {
   const params = new URLSearchParams();
   if (key) {
     params.set('key', key);
@@ -15,7 +15,7 @@ const getObjectDetails = (
   const query = params.toString();
   const endpoint = `/buckets/${bucket}/object${query ? `?${query}` : ''}`;
 
-  return api.get<BucketContentsResponse>(endpoint);
+  return api.get<ObjectDetails>(endpoint);
 };
 
 type UseObjectDetailsOptions = {

--- a/app/s3browser/src/features/file-browser/components/bucket-contents-table.tsx
+++ b/app/s3browser/src/features/file-browser/components/bucket-contents-table.tsx
@@ -4,6 +4,7 @@ import { columnDefs } from '../utils/bucket-contents-column-defs';
 import { toBucketItems } from '../utils/transform-to-bucket-items';
 import { useBucketContentsQuery } from '../api/get-bucket-contents';
 import TableBuilder from '@/components/ui/table-builder/table-builder';
+import { usePagination } from '../hooks/use-pagination'
 
 const normalizePrefix = (raw: string): string => {
   if (!raw) return '';
@@ -17,6 +18,7 @@ const BucketContentsTable = () => {
   const currentDirectory = prefix ? prefix.split('/').filter(Boolean).pop() : bucketName;
 
   const { data } = useBucketContentsQuery({ bucket: bucketName, prefix });
+  const { pagination, onPaginationChange} = usePagination();
 
   // Transform the split API response into a flat array for TanStack Table.
   // Reruns whenever the raw API response changes, but not on every render.
@@ -37,6 +39,8 @@ const BucketContentsTable = () => {
         data={items}
         columns={columns}
         initialSorting={[{ id: 'name', desc: false }]}
+        pagination={pagination}
+        onPaginationChange={onPaginationChange}
       />
     </div>
   );

--- a/app/s3browser/src/features/file-browser/components/bucket-contents-table.tsx
+++ b/app/s3browser/src/features/file-browser/components/bucket-contents-table.tsx
@@ -17,8 +17,11 @@ const BucketContentsTable = () => {
   const prefix = normalizePrefix(searchParams.get('prefix') ?? '');
   const currentDirectory = prefix ? prefix.split('/').filter(Boolean).pop() : bucketName;
 
-  const { data } = useBucketContentsQuery({ bucket: bucketName, prefix });
-  const { pagination, onPaginationChange} = usePagination();
+  const { data, isLoading } = useBucketContentsQuery({
+    bucket: bucketName,
+    prefix,
+  });
+  const { pagination, onPaginationChange } = usePagination();
 
   // Transform the split API response into a flat array for TanStack Table.
   // Reruns whenever the raw API response changes, but not on every render.
@@ -41,6 +44,7 @@ const BucketContentsTable = () => {
         initialSorting={[{ id: 'name', desc: false }]}
         pagination={pagination}
         onPaginationChange={onPaginationChange}
+        isLoading={isLoading}
       />
     </div>
   );

--- a/app/s3browser/src/features/file-browser/components/bucket-list.tsx
+++ b/app/s3browser/src/features/file-browser/components/bucket-list.tsx
@@ -18,7 +18,7 @@ const BucketList = () => {
       <TableBuilder
         data={buckets}
         columns={columnDefs as ColumnDef<Bucket>[]}
-        initialSorting={[{ id: 'bucket', desc: false }]}
+        initialSorting={[{ id: 'name', desc: false }]}
       />
     </div>
   );

--- a/app/s3browser/src/features/file-browser/components/object-detail-display.tsx
+++ b/app/s3browser/src/features/file-browser/components/object-detail-display.tsx
@@ -1,0 +1,78 @@
+import { ObjectDetails } from '@/types/api';
+import { formatSize, capitalizeStr, extractName } from '../utils/format-utils';
+
+type ObjectDetailDisplayProps = {
+  objectDetails: ObjectDetails;
+};
+
+const ObjectDetailDisplay = ({ objectDetails }: ObjectDetailDisplayProps) => {
+  const displayRetrievalTime = () => {
+    if (objectDetails.archiveStatus === 'ARCHIVE_ACCESS') {
+      return '5 hours';
+    } else if (objectDetails.archiveStatus === 'DEEP_ARCHIVE_ACCESS') {
+      return '12 hours';
+    }
+    return 'Milliseconds (instant access)';
+  }
+
+  return (
+    <div className="pt-2">
+      {/* TODO: Make this less verbose/ DRY */}
+      <h4>{extractName(objectDetails.key)}</h4>
+      <div className="border rounded p-3 mb-4 mt-3">
+        <h5 className="mb-3">Object overview</h5>
+
+        <div className="section mb-3">
+          <p className='m-0'><strong>Key</strong></p>
+          <p className="m-0">{objectDetails.key}</p>
+        </div>
+
+        <div className="section mb-3">
+          <p className='m-0'><strong>Content Type</strong></p>
+          <p className="m-0">{objectDetails.contentType}</p>
+        </div>
+
+        <div className="section mb-3">
+          <p className='m-0'><strong>Size</strong></p>
+          <p className="m-0">{formatSize(objectDetails.size)}</p>
+        </div>
+
+        <div className="section mb-3">
+          <p className='m-0'><strong>Last Modified</strong></p>
+          <p className="m-0">{new Date(objectDetails.lastModified).toLocaleString()}</p>
+        </div>
+      </div>
+
+      <div className="border rounded p-3">
+        <h5 className="mb-3">Storage class</h5>
+        <div className="section mb-3">
+          <p className='m-0'><strong>Storage Class</strong></p>
+          <p className="m-0">{capitalizeStr(objectDetails.storageClass)}</p>
+        </div>
+
+        {/* For non-standard storage classes, we display information about access tiers and retrieval time */}
+        {objectDetails.storageClass !== 'STANDARD' && (
+          <>
+            <div className="section mb-3">
+              <p className='m-0'><strong>Access Tier</strong></p>
+              {/* If storage class is Intelligent Tiering and archiveStatus is null, it means the object is in one of the frequent access, infrequent access, or archive instant access tiers */}
+              <p className="m-0">{objectDetails.archiveStatus ? capitalizeStr(objectDetails.archiveStatus) : 'Frequent Access, Infrequent Access, or Archive Instant Access tier'}</p>
+            </div>
+
+            <div className="section mb-3">
+              <p className='m-0'><strong>Retrieval time</strong></p>
+              <small className="text-muted m-0">Retrieval times depend on the access tier of an object.</small>
+              <p className="m-0">{displayRetrievalTime()}</p>
+            </div>
+            <div className="section mb-3">
+              <p className='m-0'><strong>Restoration status</strong></p>
+              <p className="m-0">{objectDetails.restoreStatus ? capitalizeStr(objectDetails.restoreStatus) : 'N/A'}</p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+};
+
+export default ObjectDetailDisplay;

--- a/app/s3browser/src/features/file-browser/components/object-detail-display.tsx
+++ b/app/s3browser/src/features/file-browser/components/object-detail-display.tsx
@@ -54,7 +54,7 @@ const ObjectDetailDisplay = ({ objectDetails }: ObjectDetailDisplayProps) => {
       </section>
 
       <section className="border rounded p-3">
-        <h5 className="mb-3">Storage Class</h5>
+        <h5 className="mb-3">Storage Details</h5>
 
         <dl className="mb-0">
           <ObjectDetailField
@@ -75,7 +75,7 @@ const ObjectDetailDisplay = ({ objectDetails }: ObjectDetailDisplayProps) => {
               />
               <ObjectDetailField
                 label="Restoration status"
-                value={restoreStatus ? capitalizeStr(restoreStatus) : 'N/A'}
+                value={restoreStatus ? capitalizeStr(restoreStatus) : 'No restoration currently in progress'}
               />
             </>
           )}

--- a/app/s3browser/src/features/file-browser/components/object-detail-display.tsx
+++ b/app/s3browser/src/features/file-browser/components/object-detail-display.tsx
@@ -1,78 +1,88 @@
+import { useMemo } from 'react';
 import { ObjectDetails } from '@/types/api';
-import { formatSize, capitalizeStr, extractName } from '../utils/format-utils';
+import { formatSize, formatLastModified, capitalizeStr, extractName, extractFileExtension } from '../utils/format-utils';
+import ObjectDetailField from './object-detail-field';
+
+const displayRetrievalTime = (archiveStatus: string | null) => {
+  switch (archiveStatus) {
+    case 'ARCHIVE_ACCESS':
+      return '5 hours';
+    case 'DEEP_ARCHIVE_ACCESS':
+      return '12 hours';
+    default:
+      return 'Milliseconds (instant access)';
+  }
+};
+
+const displayAccessTierLabel = (archiveStatus: string | null) =>
+  archiveStatus ? capitalizeStr(archiveStatus) : 'Frequent Access, Infrequent Access, or Archive Instant Access tier';
+
 
 type ObjectDetailDisplayProps = {
   objectDetails: ObjectDetails;
 };
 
 const ObjectDetailDisplay = ({ objectDetails }: ObjectDetailDisplayProps) => {
-  const displayRetrievalTime = () => {
-    if (objectDetails.archiveStatus === 'ARCHIVE_ACCESS') {
-      return '5 hours';
-    } else if (objectDetails.archiveStatus === 'DEEP_ARCHIVE_ACCESS') {
-      return '12 hours';
-    }
-    return 'Milliseconds (instant access)';
-  }
+  const {
+    key,
+    size,
+    lastModified,
+    storageClass,
+    archiveStatus,
+    restoreStatus,
+  } = objectDetails;
+
+  const isNonStandard = storageClass !== 'STANDARD';
+  const fileName = useMemo(() => extractName(key), [key]);
 
   return (
     <div className="pt-2">
-      {/* TODO: Make this less verbose/ DRY */}
-      <h4>{extractName(objectDetails.key)}</h4>
-      <div className="border rounded p-3 mb-4 mt-3">
-        <h5 className="mb-3">Object overview</h5>
+      <h4 className="mb-3">{fileName}</h4>
 
-        <div className="section mb-3">
-          <p className='m-0'><strong>Key</strong></p>
-          <p className="m-0">{objectDetails.key}</p>
-        </div>
+      <section className="border rounded p-3 mb-4">
+        <h5 className="mb-3">Object Overview</h5>
 
-        <div className="section mb-3">
-          <p className='m-0'><strong>Content Type</strong></p>
-          <p className="m-0">{objectDetails.contentType}</p>
-        </div>
+        <dl className="mb-0">
+          <ObjectDetailField
+            label="Key"
+            value={objectDetails.key}
+          />
+          <ObjectDetailField label="Type" value={extractFileExtension(fileName)} />
+          <ObjectDetailField label="Size" value={formatSize(size)} />
+          <ObjectDetailField label="Last modified" value={formatLastModified(lastModified)} />
+        </dl>
+      </section>
 
-        <div className="section mb-3">
-          <p className='m-0'><strong>Size</strong></p>
-          <p className="m-0">{formatSize(objectDetails.size)}</p>
-        </div>
+      <section className="border rounded p-3">
+        <h5 className="mb-3">Storage Class</h5>
 
-        <div className="section mb-3">
-          <p className='m-0'><strong>Last Modified</strong></p>
-          <p className="m-0">{new Date(objectDetails.lastModified).toLocaleString()}</p>
-        </div>
-      </div>
+        <dl className="mb-0">
+          <ObjectDetailField
+            label="Storage class"
+            value={capitalizeStr(storageClass)}
+          />
 
-      <div className="border rounded p-3">
-        <h5 className="mb-3">Storage class</h5>
-        <div className="section mb-3">
-          <p className='m-0'><strong>Storage Class</strong></p>
-          <p className="m-0">{capitalizeStr(objectDetails.storageClass)}</p>
-        </div>
-
-        {/* For non-standard storage classes, we display information about access tiers and retrieval time */}
-        {objectDetails.storageClass !== 'STANDARD' && (
-          <>
-            <div className="section mb-3">
-              <p className='m-0'><strong>Access Tier</strong></p>
-              {/* If storage class is Intelligent Tiering and archiveStatus is null, it means the object is in one of the frequent access, infrequent access, or archive instant access tiers */}
-              <p className="m-0">{objectDetails.archiveStatus ? capitalizeStr(objectDetails.archiveStatus) : 'Frequent Access, Infrequent Access, or Archive Instant Access tier'}</p>
-            </div>
-
-            <div className="section mb-3">
-              <p className='m-0'><strong>Retrieval time</strong></p>
-              <small className="text-muted m-0">Retrieval times depend on the access tier of an object.</small>
-              <p className="m-0">{displayRetrievalTime()}</p>
-            </div>
-            <div className="section mb-3">
-              <p className='m-0'><strong>Restoration status</strong></p>
-              <p className="m-0">{objectDetails.restoreStatus ? capitalizeStr(objectDetails.restoreStatus) : 'N/A'}</p>
-            </div>
-          </>
-        )}
-      </div>
+          {isNonStandard && (
+            <>
+              <ObjectDetailField
+                label="Access tier"
+                value={displayAccessTierLabel(archiveStatus)}
+              />
+              <ObjectDetailField
+                label="Retrieval time"
+                value={displayRetrievalTime(archiveStatus)}
+                hint="Retrieval times depend on the access tier of an object."
+              />
+              <ObjectDetailField
+                label="Restoration status"
+                value={restoreStatus ? capitalizeStr(restoreStatus) : 'N/A'}
+              />
+            </>
+          )}
+        </dl>
+      </section>
     </div>
-  )
+  );
 };
 
 export default ObjectDetailDisplay;

--- a/app/s3browser/src/features/file-browser/components/object-detail-field.tsx
+++ b/app/s3browser/src/features/file-browser/components/object-detail-field.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+type ObjectDetailFieldProps = {
+  label: string;
+  value: ReactNode;
+  hint?: string;
+};
+
+const ObjectDetailField = ({ label, value, hint }: ObjectDetailFieldProps) => (
+  <div className="mb-3">
+    <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+      {label}
+    </dt>
+    <dd className="mb-0">
+      {value}
+      {hint && <small className="d-block text-muted mt-1">{hint}</small>}
+    </dd>
+  </div>
+);
+
+export default ObjectDetailField;

--- a/app/s3browser/src/features/file-browser/hooks/use-pagination.tsx
+++ b/app/s3browser/src/features/file-browser/hooks/use-pagination.tsx
@@ -1,0 +1,36 @@
+import { useSearchParams } from "react-router";
+import { PaginationState, Updater } from "@tanstack/react-table";
+
+const PAGE_SIZE = 50;
+
+export const usePagination = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const pageFromUrl = parseInt(searchParams.get("page") ?? "1", 10);
+  const pageIndex = pageFromUrl > 0 ? pageFromUrl - 1 : 0;
+
+  const pagination: PaginationState = {
+    pageIndex,
+    pageSize: PAGE_SIZE,
+  };
+
+  // TanStack Table calls onPaginationChange with either a new PaginationState
+  // or an updater function (prevState) => newState.
+  const onPaginationChange = (updater: Updater<PaginationState>) => {
+    const newState =
+      typeof updater === "function" ? updater(pagination) : updater;
+
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      // Store 1-based page in URL; don't include the param on page 1 for a cleaner URL
+      if (newState.pageIndex <= 0) {
+        next.delete("page");
+      } else {
+        next.set("page", (newState.pageIndex + 1).toString());
+      }
+      return next;
+    });
+  };
+
+  return { pagination, onPaginationChange };
+};

--- a/app/s3browser/src/features/file-browser/hooks/use-pagination.tsx
+++ b/app/s3browser/src/features/file-browser/hooks/use-pagination.tsx
@@ -20,6 +20,11 @@ export const usePagination = () => {
     const newState =
       typeof updater === "function" ? updater(pagination) : updater;
 
+    // Don't set the URL if the page hasn't actually changed.
+    // This prevents TanStack Table's autoResetPageIndex from
+    // pushing empty history entries on every data load.
+    if (newState.pageIndex === pageIndex) return;
+
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       // Store 1-based page in URL; don't include the param on page 1 for a cleaner URL
@@ -29,7 +34,7 @@ export const usePagination = () => {
         next.set("page", (newState.pageIndex + 1).toString());
       }
       return next;
-    });
+    }, { replace: true });
   };
 
   return { pagination, onPaginationChange };

--- a/app/s3browser/src/features/file-browser/utils/bucket-contents-column-defs.tsx
+++ b/app/s3browser/src/features/file-browser/utils/bucket-contents-column-defs.tsx
@@ -1,14 +1,9 @@
 import { Link } from 'react-router'
 import { createColumnHelper } from '@tanstack/react-table'
 import { BucketItem } from '@/types/api'
-import { capitalizeStr, formatSize } from './format-utils';
+import { capitalizeStr, extractFileExtension, formatSize, formatLastModified } from './format-utils';
 
 const columnHelper = createColumnHelper<BucketItem>()
-
-const extractFileExtension = (fileName: string) => {
-  const parts = fileName.split('.');
-  return parts.length > 1 ? parts.pop() : 'unknown';
-}
 
 const sortByTypeAndExtension = (a: BucketItem, b: BucketItem) => {
   if (a.type !== b.type) {
@@ -27,14 +22,6 @@ const sortByTypeAndExtension = (a: BucketItem, b: BucketItem) => {
 
   return a.name.localeCompare(b.name);
 }
-
-const formatLastModified = (dateString: string): string => {
-  const date = new Date(dateString);
-  const pad = (n: number) => n.toString().padStart(2, '0');
-
-  return `${date.toLocaleString('en-US', { month: 'long' })} ${date.getDate()}, ${date.getFullYear()}, ` +
-    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-};
 
 export const columnDefs = (bucket: string) => [
   columnHelper.accessor('name', {

--- a/app/s3browser/src/features/file-browser/utils/bucket-contents-column-defs.tsx
+++ b/app/s3browser/src/features/file-browser/utils/bucket-contents-column-defs.tsx
@@ -1,16 +1,9 @@
 import { Link } from 'react-router'
 import { createColumnHelper } from '@tanstack/react-table'
 import { BucketItem } from '@/types/api'
+import { capitalizeStr, formatSize } from './format-utils';
 
 const columnHelper = createColumnHelper<BucketItem>()
-
-// TODO: These formatting functions could be moved to a shared utils file if we need them elsewhere in the app.
-const capitalizeStr = (str: string) => {
-  return str.toLowerCase()
-    .split('_')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
 
 const extractFileExtension = (fileName: string) => {
   const parts = fileName.split('.');
@@ -35,19 +28,6 @@ const sortByTypeAndExtension = (a: BucketItem, b: BucketItem) => {
   return a.name.localeCompare(b.name);
 }
 
-const formatSize = (sizeInBytes: number) => {
-  const units = ['B', 'kB', 'MB', 'GB', 'TB'];
-  let size = sizeInBytes;
-  let unitIndex = 0;
-
-  while (size >= 1024 && unitIndex < units.length - 1) {
-    size /= 1024;
-    unitIndex++;
-  }
-
-  return `${size.toFixed(2)} ${units[unitIndex]}`;
-}
-
 const formatLastModified = (dateString: string): string => {
   const date = new Date(dateString);
   const pad = (n: number) => n.toString().padStart(2, '0');
@@ -60,8 +40,9 @@ export const columnDefs = (bucket: string) => [
   columnHelper.accessor('name', {
     header: 'Name',
     cell: ({ row }) => {
-      const pathWithBucket = `${bucket}?prefix=${encodeURIComponent(row.original.fullPath)}`;
-      const url = row.original.type === 'folder' ? `/buckets/${pathWithBucket}` : `/object/${pathWithBucket}`;
+      const bucketPath = `/buckets/${bucket}`;
+      const prefix = row.original.fullPath ? `?prefix=${encodeURIComponent(row.original.fullPath)}` : '';
+      const url = row.original.type === 'folder' ? `${bucketPath}${prefix}` : `${bucketPath}/object-details${prefix}`;
 
       return (
         <Link

--- a/app/s3browser/src/features/file-browser/utils/format-utils.ts
+++ b/app/s3browser/src/features/file-browser/utils/format-utils.ts
@@ -1,0 +1,25 @@
+export const formatSize = (sizeInBytes: number) => {
+  const units = ['B', 'kB', 'MB', 'GB', 'TB'];
+  let size = sizeInBytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return unitIndex === 0 ? `${size} ${units[unitIndex]}` : `${size.toFixed(2)} ${units[unitIndex]}`;
+}
+
+export const capitalizeStr = (str: string) => {
+  return str.toLowerCase()
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export const extractName = (fullPath: string): string => {
+  const trimmed = fullPath.endsWith('/') ? fullPath.slice(0, -1) : fullPath;
+  const lastSlash = trimmed.lastIndexOf('/');
+  return lastSlash === -1 ? trimmed : trimmed.slice(lastSlash + 1);
+};

--- a/app/s3browser/src/features/file-browser/utils/format-utils.ts
+++ b/app/s3browser/src/features/file-browser/utils/format-utils.ts
@@ -1,4 +1,4 @@
-export const formatSize = (sizeInBytes: number) => {
+const formatSize = (sizeInBytes: number) => {
   const units = ['B', 'kB', 'MB', 'GB', 'TB'];
   let size = sizeInBytes;
   let unitIndex = 0;
@@ -11,15 +11,30 @@ export const formatSize = (sizeInBytes: number) => {
   return unitIndex === 0 ? `${size} ${units[unitIndex]}` : `${size.toFixed(2)} ${units[unitIndex]}`;
 }
 
-export const capitalizeStr = (str: string) => {
+const capitalizeStr = (str: string) => {
   return str.toLowerCase()
     .split('_')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
 }
 
-export const extractName = (fullPath: string): string => {
+const extractName = (fullPath: string): string => {
   const trimmed = fullPath.endsWith('/') ? fullPath.slice(0, -1) : fullPath;
   const lastSlash = trimmed.lastIndexOf('/');
   return lastSlash === -1 ? trimmed : trimmed.slice(lastSlash + 1);
 };
+
+const formatLastModified = (dateString: string): string => {
+  const date = new Date(dateString);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
+  return `${date.toLocaleString('en-US', { month: 'long' })} ${date.getDate()}, ${date.getFullYear()}, ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+const extractFileExtension = (fileName: string) => {
+  const parts = fileName.split('.');
+  return parts.length > 1 ? parts.pop() : 'unknown';
+}
+
+export { formatSize, capitalizeStr, extractName, formatLastModified, extractFileExtension };

--- a/app/s3browser/src/features/file-browser/utils/transform-to-bucket-items.ts
+++ b/app/s3browser/src/features/file-browser/utils/transform-to-bucket-items.ts
@@ -1,11 +1,6 @@
 
 import { BucketContentsResponse, BucketItem } from '@/types/api';
-
-const extractName = (fullPath: string): string => {
-  const trimmed = fullPath.endsWith('/') ? fullPath.slice(0, -1) : fullPath;
-  const lastSlash = trimmed.lastIndexOf('/');
-  return lastSlash === -1 ? trimmed : trimmed.slice(lastSlash + 1);
-};
+import { extractName } from './format-utils';
 
 // This function transforms the raw API response for bucket contents into a format suitable for the table component.
 // The API currently returns separate lists for folders and objects, but the table expects a single list of items.

--- a/app/s3browser/src/lib/api-client.ts
+++ b/app/s3browser/src/lib/api-client.ts
@@ -1,13 +1,10 @@
 import { useNotifications } from '@/stores/notifications-store';
 import { ErrorData } from '@/types/api';
+import { ApiError } from './api-error';
+
+export { ApiError };
 
 const BASE_URL = '/api';
-
-// ? Maybe we should rely on the backend to provide more user-friendly error messages
-const AWS_ERROR_MESSAGES: Record<string, string> = {
-  AccessDenied:
-    'You do not have permission to access this resource. The AWS credentials may have been rotated.',
-};
 
 const isErrorData = (data: unknown): data is ErrorData =>
   typeof data === 'object' &&
@@ -15,21 +12,55 @@ const isErrorData = (data: unknown): data is ErrorData =>
   'error' in data &&
   typeof (data as Record<string, unknown>).error === 'string';
 
-const notifyError = (status: number, raw: unknown) => {
-  const data = isErrorData(raw) ? raw : null;
-  const code = data?.code;
-  const error = data?.error ?? 'An unexpected error occurred.';
+// Attempt to parse the response body as JSON
+const parseErrorBody = async (
+  response: Response,
+): Promise<ErrorData | null> => {
+  try {
+    const json: unknown = await response.json();
+    return isErrorData(json) ? json : null;
+  } catch {
+    return null;
+  }
+};
+
+// Decide whether a toast should be shown for this particular failure.
+// This is more flexible than a simple `silent` boolean because it allows for suppressing toasts
+// for expected failure cases.
+const shouldSilence = (
+  silent: boolean | number[] | undefined,
+  status: number,
+): boolean => {
+  if (silent === true) return true;
+  if (Array.isArray(silent)) return silent.includes(status);
+
+  return false;
+};
+
+const notifyError = (status: number, data: ErrorData | null) => {
+  const message = data?.error ?? 'An unexpected error occurred.';
 
   useNotifications.getState().addNotification({
     type: 'error',
-    title: code ? `AWS ${status} Error: ${code})` : `${status} Error`,
-    message: code ? (AWS_ERROR_MESSAGES[code] ?? error) : error,
+    title: `${status} Error`,
+    message,
   });
 };
 
-type RequestOptions = RequestInit & { silent?: boolean };
+type RequestOptions = RequestInit & {
+  /**
+    Controls whether error toasts are shown.
+     - true - never show a toast
+     - number[] - suppress toasts for these HTTP status codes only, eg. `[404, 500]`
+     - undefined - always show a toast on failure (default)
+    */
+  silent?: boolean | number[];
+};
 
-async function request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+async function request<T>(
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<T> {
   const { silent, ...fetchOptions } = options;
 
   const response = await fetch(`${BASE_URL}${endpoint}`, {
@@ -43,11 +74,14 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => null);
-    if (!silent) notifyError(response.status, errorData);
+    const errorData = await parseErrorBody(response);
+
+    if (!shouldSilence(silent, response.status)) {
+      notifyError(response.status, errorData);
+    }
 
     // Throw the parsed error data so React Query can access it
-    throw new Error(response.statusText || `HTTP ${response.status}`);
+    throw new ApiError(response.status, response.statusText, errorData);
   }
 
   return response.json();

--- a/app/s3browser/src/lib/api-client.ts
+++ b/app/s3browser/src/lib/api-client.ts
@@ -1,31 +1,59 @@
+import { useNotifications } from '@/stores/notifications-store';
+import { ErrorData } from '@/types/api';
+
 const BASE_URL = '/api';
 
-async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
-  const config: RequestInit = {
-    ...options,
+// ? Maybe we should rely on the backend to provide more user-friendly error messages
+const AWS_ERROR_MESSAGES: Record<string, string> = {
+  AccessDenied:
+    'You do not have permission to access this resource. The AWS credentials may have been rotated.',
+};
+
+const isErrorData = (data: unknown): data is ErrorData =>
+  typeof data === 'object' &&
+  data !== null &&
+  'error' in data &&
+  typeof (data as Record<string, unknown>).error === 'string';
+
+const notifyError = (status: number, raw: unknown) => {
+  const data = isErrorData(raw) ? raw : null;
+  const code = data?.code;
+  const error = data?.error ?? 'An unexpected error occurred.';
+
+  useNotifications.getState().addNotification({
+    type: 'error',
+    title: code ? `AWS ${status} Error: ${code})` : `${status} Error`,
+    message: code ? (AWS_ERROR_MESSAGES[code] ?? error) : error,
+  });
+};
+
+type RequestOptions = RequestInit & { silent?: boolean };
+
+async function request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+  const { silent, ...fetchOptions } = options;
+
+  const response = await fetch(`${BASE_URL}${endpoint}`, {
+    ...fetchOptions,
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
-      ...options?.headers,
+      ...fetchOptions?.headers,
     },
     credentials: 'include',
-  };
-
-  const response = await fetch(`${BASE_URL}${endpoint}`, config);
+  });
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => null);
-    
+    if (!silent) notifyError(response.status, errorData);
+
     // Throw the parsed error data so React Query can access it
-    const error = new Error(response.statusText) as { response?: unknown };
-    error.response = errorData;
-    throw error;
+    throw new Error(response.statusText || `HTTP ${response.status}`);
   }
 
   return response.json();
 }
 
 export const api = {
-  get: <T>(endpoint: string) =>
-    request<T>(endpoint, { method: 'GET' }),
+  get: <T>(endpoint: string, options?: Omit<RequestOptions, 'method'>) =>
+    request<T>(endpoint, { ...options, method: 'GET' }),
 };

--- a/app/s3browser/src/lib/api-error.ts
+++ b/app/s3browser/src/lib/api-error.ts
@@ -1,0 +1,23 @@
+import { ErrorData } from "@/types/api";
+
+/**
+ Structured error class for API responses outside the 2xx range.
+
+ Throwing this instead of a plain error lets any downstream code
+ (React Query `onError`, error boundaries) inspect the HTTP status 
+ and the parsed response body without having to re-parse anything.
+*/
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    public data: ErrorData | null,
+  ) {
+    super((data?.error ?? statusText) || `HTTP ${status}`);
+    this.name = "ApiError";
+  }
+
+  get isServerError(): boolean {
+    return this.status >= 500;
+  }
+}

--- a/app/s3browser/src/lib/auth.ts
+++ b/app/s3browser/src/lib/auth.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import { User } from "@/types/api";
+
+export const AUTH_QUERY_KEY = ["authenticated-user"];
+
+async function getCurrentUser(): Promise<User | null> {
+  try {
+    const response = await api.get<{ user: User | null }>("/users/_self", {
+      // Unauthenticated users will be redirected to login page,
+      // so we can treat this as a non-error case and avoid showing a toast notification.
+      silent: true,
+    });
+    return response.user;
+  } catch (error) {
+    console.error("Error fetching current user:", error);
+    return null;
+  }
+}
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: AUTH_QUERY_KEY,
+    queryFn: getCurrentUser,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    gcTime: 1000 * 60 * 30, // 30 minutes cache garbage collection
+    retry: false,
+  });
+}

--- a/app/s3browser/src/lib/auth.ts
+++ b/app/s3browser/src/lib/auth.ts
@@ -6,12 +6,11 @@ export const AUTH_QUERY_KEY = ["authenticated-user"];
 
 async function getCurrentUser(): Promise<User | null> {
   try {
-    const response = await api.get<{ user: User | null }>("/users/_self", {
+    return api.get<User | null>("/users/_self", {
       // Unauthenticated users will be redirected to login page,
       // so we can treat this as a non-error case and avoid showing a toast notification.
       silent: true,
     });
-    return response.user;
   } catch (error) {
     console.error("Error fetching current user:", error);
     return null;

--- a/app/s3browser/src/stores/notifications-store.ts
+++ b/app/s3browser/src/stores/notifications-store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+export type Notification = {
+  id: string;
+  type: 'success' | 'error' | 'info' | 'warning';
+  title: string;
+  message?: string;
+};
+
+type NotificationsStore = {
+  notifications: Notification[];
+  addNotification: (notification: Omit<Notification, 'id'>) => void;
+  dismissNotification: (id: string) => void;
+};
+
+/**
+ * Use this hook to manage global notifications across the app. Generally, we prefer to use alerts closer 
+ * to the source of the event (e.g. within a form or component), but this store is useful for triggering notifications 
+ * from non-component code (e.g. utility functions, API clients) or for displaying messages when the form or component is unmounted 
+ * (e.g. successful deletion of a resource that triggers a redirect).
+ */
+export const useNotifications = create<NotificationsStore>((set) => ({
+  notifications: [],
+  addNotification: (notification) =>
+    set((state) => ({
+      notifications: [...state.notifications, { ...notification, id: crypto.randomUUID() }],
+    })),
+  dismissNotification: (id) =>
+    set((state) => ({
+      notifications: state.notifications.filter((n) => n.id !== id),
+    })),
+}));

--- a/app/s3browser/src/types/api.ts
+++ b/app/s3browser/src/types/api.ts
@@ -52,8 +52,6 @@ export type User = {
   email: string;
 };
 
-// Temp: this could change later
 export type ErrorData = {
-  error: string; // error message
-  code?: string; // AWS error code, if applicable (e.g. "NoSuchBucket")
+  error: string;
 };

--- a/app/s3browser/src/types/api.ts
+++ b/app/s3browser/src/types/api.ts
@@ -19,6 +19,16 @@ export interface BucketContentsResponse {
   folders: string[];
 }
 
+export type ObjectDetails = {
+  key: string;
+  bucket: string;
+  size: number;
+  contentType: string;
+  lastModified: string;
+  storageClass: string;
+  archiveStatus: string | null;
+  restoreStatus: string | null;
+};
 
 // A row type for the bucket contents table.
 // Each item is either a folder or an object, distinguished by the `type` field.

--- a/app/s3browser/src/types/api.ts
+++ b/app/s3browser/src/types/api.ts
@@ -46,3 +46,14 @@ export type BucketItem =
     lastModified: string;
     storageClass: string;
   };
+
+export type User = {
+  uid: string;
+  email: string;
+};
+
+// Temp: this could change later
+export type ErrorData = {
+  error: string; // error message
+  code?: string; // AWS error code, if applicable (e.g. "NoSuchBucket")
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,7 @@ export default tseslint.config(
   // Disable incompatible-library warnings for TanStack Table components
   // https://github.com/facebook/react/issues/33057
   {
-    files: ['**/table-builder.tsx', '**/table-builder-virtualizer.tsx'],
+    files: ['**/table-builder.tsx'],
     rules: {
       'react-hooks/incompatible-library': 'off',
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-dom": "19.2.3",
     "react-error-boundary": "^6.1.1",
     "react-router": "^7.15.0",
-    "sass": "^1.66.1"
+    "sass": "^1.66.1",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
@@ -39,6 +40,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^17.6.0",
+    "prettier": "3.8.3",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "vite": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^17.6.0",
-    "prettier": "3.8.3",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "vite": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^7.0.1"
     globals: "npm:^17.6.0"
+    prettier: "npm:3.8.3"
     react: "npm:19.2.3"
     react-bootstrap: "npm:^2.10.10"
     react-dom: "npm:19.2.3"
@@ -1232,6 +1233,7 @@ __metadata:
     typescript-eslint: "npm:^8.53.1"
     vite: "npm:^8.0.0"
     vite-plugin-ruby: "npm:^5.2.0"
+    zustand: "npm:^5.0.13"
   languageName: unknown
   linkType: soft
 
@@ -3217,6 +3219,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:3.8.3":
+  version: 3.8.3
+  resolution: "prettier@npm:3.8.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/754816fd7593eb80f6376d7476d463e832c38a12f32775a82683adb6e35b772b1f484d65f19401507b983a8c8a7cd5a4a9f12006bd56491e8f35503473f77473
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^6.0.0":
   version: 6.1.0
   resolution: "proc-log@npm:6.1.0"
@@ -4236,5 +4247,26 @@ __metadata:
   version: 4.4.1
   resolution: "zod@npm:4.4.1"
   checksum: 10c0/55714c4bea81f7851ac46bf9edfde7c63ed6677a6cc8971ed3a526a079de3ffbe2bd56160327d22e070f72854fc4485b98ab7373255b6b69d64d9067caec864e
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "zustand@npm:5.0.13"
+  peerDependencies:
+    "@types/react": ">=18.0.0"
+    immer: ">=9.0.6"
+    react: ">=18.0.0"
+    use-sync-external-store: ">=1.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+    use-sync-external-store:
+      optional: true
+  checksum: 10c0/e4e76af1c324c797e3cc6ef094cb15c5884ca6713697140c2be292b2c612f5445fa21d222671b97797a4376154cac14a140f05728f0ac17b4b9e10f45e0ff29e
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,7 +1222,6 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^7.0.1"
     globals: "npm:^17.6.0"
-    prettier: "npm:3.8.3"
     react: "npm:19.2.3"
     react-bootstrap: "npm:^2.10.10"
     react-dom: "npm:19.2.3"
@@ -3216,15 +3215,6 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
-  languageName: node
-  linkType: hard
-
-"prettier@npm:3.8.3":
-  version: 3.8.3
-  resolution: "prettier@npm:3.8.3"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10c0/754816fd7593eb80f6376d7476d463e832c38a12f32775a82683adb6e35b772b1f484d65f19401507b983a8c8a7cd5a4a9f12006bd56491e8f35503473f77473
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Part of [DSM-161](https://columbiauniversitylibraries.atlassian.net/browse/DSM-161)

## Overview
This PR adds the Object Details page, which displays S3 object metadata split into two sections: general information (key, type, size, last modified) and storage class details (access tier, retrieval time, restoration status). It also enhances `TableBuilder` with URL-driven pagination and adds a loading state for data fetches.

## URL-driven pagination for TableBuilder
`TableBuilder` now supports controlled pagination via search params (`?page=4`), allowing users to bookmark or share specific pages. Internal (uncontrolled) pagination is still the default when no pagination props are passed. The URL sync logic lives in a separate `usePagination` hook.

## Object details route change
The object details route was moved from `/object/:bucketName?prefix=ac/bd/text.txt` to `/buckets/:bucketName/object-details?prefix=ac/bd/text.txt` so it shares the main layout that includes breadcrumbs. The exact route path is TBD.

## Loading state for bucket contents
Typically we use `useSuspenseQuery` with a Suspense boundary for potentially slow data fetches. For the reusable `TableBuilder` this was too complex, as the loading boundary would need to wrap the entire table, making the component harder to reuse. Instead, TableBuilder accepts an optional `isLoading` prop, derived from `useQuery`, which makes it more straightforward to use.

UI/UX note: The loading state currently shows a spinner. I tried skeleton rows, but they looked confusing since we don't know how many rows to expect, so a high skeleton count followed by a single result (or a low count followed by 50 rows) felt jarring. A smoother approach might be to animate rows when the data loads (this can be discussed later, as it's not a priority for v1).