### PR TITLE
DSM-170: Update links and add redirects to '/browse/buckets'

### DIFF
--- a/app/s3browser/src/app/router.tsx
+++ b/app/s3browser/src/app/router.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
-import { createBrowserRouter, LoaderFunction, ActionFunction } from 'react-router';
+import { createBrowserRouter, LoaderFunction, ActionFunction, redirect } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 import { Spinner } from 'react-bootstrap';
 import MainLayout from '@/components/layouts/main-layout';
@@ -33,37 +33,44 @@ export const createAppRouter = (queryClient: QueryClient) =>
       children: [
         {
           index: true,
-          Component: () => <div>This is the root of the React app.</div>,
+          loader: () => redirect('/browse/buckets'),
         },
         {
-          Component: MainLayout,
-          path: 'buckets',
+          path: 'browse',
           children: [
             {
               index: true,
-              lazy: () => import('./routes/buckets').then(convert(queryClient)),
+              loader: () => redirect('/browse/buckets'),
             },
             {
-              path: ':bucketName',
-              lazy: () => import('./routes/bucket-contents').then(convert(queryClient)),
-            },
-            {
-              path: ':bucketName/object-details',
-              lazy: () => import('./routes/object-details').then(convert(queryClient)),
-              // This route uses useSuspenseQuery, so we want to ensure any errors are caught by the route error boundary
-              errorElement: <RouteErrorFallback errorMessage="Error loading object details. Please try again." />,
+              Component: MainLayout,
+              path: 'buckets',
+              children: [
+                {
+                  index: true,
+                  lazy: () => import('./routes/buckets').then(convert(queryClient)),
+                },
+                {
+                  path: ':bucketName',
+                  lazy: () => import('./routes/bucket-contents').then(convert(queryClient)),
+                },
+                {
+                  path: ':bucketName/object-details',
+                  lazy: () => import('./routes/object-details').then(convert(queryClient)),
+                  // This route uses useSuspenseQuery, so we want to ensure any errors are caught by the route error boundary
+                  errorElement: <RouteErrorFallback errorMessage="Error loading object details. Please try again." />,
+                },
+              ],
             },
           ],
         },
+        {
+          path: '*',
+          lazy: () => import('./routes/not-found').then(convert(queryClient)),
+        },
       ],
     },
-    {
-      path: '*',
-      lazy: () => import('./routes/not-found').then(convert(queryClient)),
-    },
-  ], {
-    basename: '/browse',
-  });
+  ]);
 
 export const AppRouter = () => {
   const queryClient = useQueryClient();

--- a/app/s3browser/src/features/file-browser/components/breadcrumbs.tsx
+++ b/app/s3browser/src/features/file-browser/components/breadcrumbs.tsx
@@ -10,13 +10,14 @@ const buildSegments = (
   bucketName?: string,
   prefix?: string,
 ) => {
+  const allBucketsPath = '/browse/buckets';
   const segments = [
-    { label: 'All Buckets', to: '/buckets' },
+    { label: 'All Buckets', to: allBucketsPath },
   ];
 
   if (!bucketName) return segments;
 
-  const bucketPath = `/buckets/${encodeURIComponent(bucketName)}`;
+  const bucketPath = `${allBucketsPath}/${encodeURIComponent(bucketName)}`;
 
   segments.push({
     label: bucketName,

--- a/app/s3browser/src/features/file-browser/utils/bucket-contents-column-defs.tsx
+++ b/app/s3browser/src/features/file-browser/utils/bucket-contents-column-defs.tsx
@@ -27,7 +27,7 @@ export const columnDefs = (bucket: string) => [
   columnHelper.accessor('name', {
     header: 'Name',
     cell: ({ row }) => {
-      const bucketPath = `/buckets/${bucket}`;
+      const bucketPath = `/browse/buckets/${bucket}`;
       const prefix = row.original.fullPath ? `?prefix=${encodeURIComponent(row.original.fullPath)}` : '';
       const url = row.original.type === 'folder' ? `${bucketPath}${prefix}` : `${bucketPath}/object-details${prefix}`;
 

--- a/app/s3browser/src/features/file-browser/utils/bucket-list-column-defs.tsx
+++ b/app/s3browser/src/features/file-browser/utils/bucket-list-column-defs.tsx
@@ -9,7 +9,7 @@ export const columnDefs = [
     header: 'Name',
     cell: ({ row }) => (
       <Link
-        to={{ pathname: `/buckets/${encodeURIComponent(row.original.name)}` }}
+        to={{ pathname: `${encodeURIComponent(row.original.name)}` }}
         className="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
       >
         <span>{row.original.name}</span>


### PR DESCRIPTION
# Ticket [DSM-170](https://columbiauniversitylibraries.atlassian.net/browse/DSM-170)

This PR updates frontend routes to match backend changes: the React app is now mounted at the application root `/`, not at `/browse`. The `basename: '/browse'` was removed accordingly, and links and redirects were updated to match the new behavior. To avoid showing users empty pages,  `/` and `/browse` both redirect to `/browse/buckets`.