### PR TITLE
DSM-172: Pagination bug fixes and tests

### DIFF
--- a/app/javascript/src/app/routes/__tests__/bucket-contents.test.tsx
+++ b/app/javascript/src/app/routes/__tests__/bucket-contents.test.tsx
@@ -2,12 +2,14 @@ import { describe, it, expect } from 'vitest';
 import {
   buildBucketContents,
   buildS3Object,
+  buildS3Objects,
   mockApi,
   renderApp,
   screen,
   within,
   waitForElementToBeRemoved,
   userEvent,
+  renderAppWithRouter,
 } from '@/testing/test-utils';
 import BucketContentsTable from '@/features/file-browser/components/bucket-contents-table';
 
@@ -203,6 +205,115 @@ describe('BucketContentsRoute', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Size' }));
 
       expect(getNameOrder()).toEqual(['small.txt', 'big.txt', 'folder']);
+    });
+  });
+
+  describe('paginating bucket contents', () => {
+    const PAGE_SIZE = 3;
+
+    const renderPaginatedAndWait = async (url = '/browse/buckets/my-bucket') => {
+      const result = await renderAppWithRouter(<BucketContentsTable pageSize={PAGE_SIZE} />, {
+        url,
+        path: '/browse/buckets/:bucketName',
+      });
+      await waitForElementToBeRemoved(() => screen.queryByRole('status'));
+      return result;
+    };
+
+    // Bootstrap's pagination buttons
+    const nav = {
+      first: /^first$/i,
+      previous: /^previous$/i,
+      next: /^next$/i,
+      last: /^last$/i,
+    };
+
+    it('advances to the next page when the next arrow is clicked', async () => {
+      mockApi(
+        'get',
+        '/buckets/my-bucket/list',
+        buildBucketContents({ objects: buildS3Objects(10) }),
+      );
+
+      const { router } = await renderPaginatedAndWait();
+
+      expect(screen.getByText('object-000.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-003.txt')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: nav.next }));
+
+      expect(await screen.findByText('object-003.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-000.txt')).not.toBeInTheDocument();
+      expect(router.state.location.search).toBe('?page=2');
+    });
+
+    it('returns to the previous page when the previous arrow is clicked', async () => {
+      mockApi(
+        'get',
+        '/buckets/my-bucket/list',
+        buildBucketContents({ objects: buildS3Objects(10) }),
+      );
+
+      const { router } = await renderPaginatedAndWait('/browse/buckets/my-bucket?page=2');
+
+      expect(screen.getByText('object-003.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-000.txt')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: nav.previous }));
+
+      expect(await screen.findByText('object-000.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-003.txt')).not.toBeInTheDocument();
+      expect(router.state.location.search).toBe('');
+    });
+
+    it('disables the navigation arrows when there is only one page', async () => {
+      mockApi(
+        'get',
+        '/buckets/my-bucket/list',
+        buildBucketContents({ objects: buildS3Objects(2) }),
+      );
+
+      await renderPaginatedAndWait();
+
+      // Bootstrap renders a disabled pagination control as a plain <span>
+      // (no buttons) so we check if buttons are absent rather than disabled
+      expect(screen.queryByRole('button', { name: nav.first })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: nav.previous })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: nav.next })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: nav.last })).not.toBeInTheDocument();
+    });
+
+    it('jumps to the last and first pages with the double-arrow buttons', async () => {
+      mockApi(
+        'get',
+        '/buckets/my-bucket/list',
+        buildBucketContents({ objects: buildS3Objects(10) }),
+      );
+
+      await renderPaginatedAndWait();
+
+      // Last page holds the final object only
+      await userEvent.click(screen.getByRole('button', { name: nav.last }));
+      expect(await screen.findByText('object-009.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-000.txt')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: nav.first }));
+      expect(await screen.findByText('object-000.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-009.txt')).not.toBeInTheDocument();
+    });
+
+    it('lands on the requested page when navigating directly to ?page=4', async () => {
+      mockApi(
+        'get',
+        '/buckets/my-bucket/list',
+        buildBucketContents({ objects: buildS3Objects(10) }),
+      );
+
+      const { router } = await renderPaginatedAndWait('/browse/buckets/my-bucket?page=4');
+
+      expect(screen.getByText('object-009.txt')).toBeInTheDocument();
+      expect(screen.queryByText('object-000.txt')).not.toBeInTheDocument();
+      expect(router.state.location.search).toBe('?page=4');
     });
   });
 });

--- a/app/javascript/src/components/ui/table-builder/table-builder.tsx
+++ b/app/javascript/src/components/ui/table-builder/table-builder.tsx
@@ -25,7 +25,7 @@ interface TableBuilderProps<T> {
   isLoading?: boolean;
 }
 
-const DEFAULT_PAGE_SIZE = 50;
+export const DEFAULT_PAGE_SIZE = 50;
 
 // This is a generic table component that can be reused across different data types
 // When using this component, ensure you specify how to render each column in the column definitions
@@ -66,12 +66,14 @@ function TableBuilder<T extends object>({
     onSortingChange: setSorting,
     onPaginationChange: effectiveOnPaginationChange,
     getPaginationRowModel: getPaginationRowModel(),
+    // Prevent setting pageIndex to 0 on data changes when pagination
+    // is controlled externally (eg. via URL)
+    autoResetPageIndex: !isPaginationControlled,
   });
 
   return (
     <>
       {/* TODO: Keep this always above the fold */}
-      {/* ? Don't render pagination if there's only one page */}
       <TablePagination table={table} />
 
       <BTable striped bordered hover responsive size="md" className="rounded-4">

--- a/app/javascript/src/components/ui/table-builder/table-pagination.tsx
+++ b/app/javascript/src/components/ui/table-builder/table-pagination.tsx
@@ -7,17 +7,17 @@ interface TablePaginationProps<T> {
 
 // Based on https://tanstack.com/table/v8/docs/framework/react/examples/pagination
 function TablePagination<T>({ table }: TablePaginationProps<T>) {
-  const { pageIndex } = table.getState().pagination;
-  const pageCount = table.getPageCount();
-  const startRow = pageIndex * table.getState().pagination.pageSize + 1;
-  const endRow = Math.min(
-    (pageIndex + 1) * table.getState().pagination.pageSize,
-    table.getFilteredRowModel().rows.length,
-  );
+  const { pageIndex, pageSize } = table.getState().pagination;
+  const totalRows = table.getFilteredRowModel().rows.length;
+
+  // An empty table has a page count of 0 but we still want to display
+  // the page as "1 of 1" rather than "1 of 0", so floor the displayed count at 1.
+  const pageCount = Math.max(table.getPageCount(), 1);
+  const startRow = totalRows === 0 ? 0 : pageIndex * pageSize + 1;
+  const endRow = Math.min((pageIndex + 1) * pageSize, totalRows);
 
   return (
     <Pagination className="mt-2">
-      {/* TODO: Display how many items are being shown */}
       <Pagination.First onClick={() => table.firstPage()} disabled={!table.getCanPreviousPage()} />
       <Pagination.Prev
         onClick={() => table.previousPage()}
@@ -29,7 +29,7 @@ function TablePagination<T>({ table }: TablePaginationProps<T>) {
       <Pagination.Next onClick={() => table.nextPage()} disabled={!table.getCanNextPage()} />
       <Pagination.Last onClick={() => table.lastPage()} disabled={!table.getCanNextPage()} />
       <div className="d-flex align-items-center p-2">
-        Showing {startRow}-{endRow} of {table.getFilteredRowModel().rows.length}
+        Showing {startRow}-{endRow} of {totalRows}
       </div>
     </Pagination>
   );

--- a/app/javascript/src/features/file-browser/components/bucket-contents-table.tsx
+++ b/app/javascript/src/features/file-browser/components/bucket-contents-table.tsx
@@ -7,7 +7,11 @@ import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { usePagination } from '../hooks/use-pagination';
 import { normalizePrefix } from '../utils/format-utils';
 
-const BucketContentsTable = () => {
+interface BucketContentsTableProps {
+  pageSize?: number;
+}
+
+const BucketContentsTable = ({ pageSize }: BucketContentsTableProps) => {
   const { bucketName } = useParams();
   const [searchParams] = useSearchParams();
   const prefix = normalizePrefix(searchParams.get('prefix') ?? '');
@@ -17,7 +21,7 @@ const BucketContentsTable = () => {
     bucket: bucketName,
     prefix,
   });
-  const { pagination, onPaginationChange } = usePagination();
+  const { pagination, onPaginationChange } = usePagination(pageSize);
 
   // Transform the split API response into a flat array for TanStack Table.
   // Reruns whenever the raw API response changes, but not on every render.
@@ -42,6 +46,7 @@ const BucketContentsTable = () => {
         initialSorting={[{ id: 'name', desc: false }]}
         pagination={pagination}
         onPaginationChange={onPaginationChange}
+        pageSize={pageSize}
         isLoading={isLoading}
       />
     </div>

--- a/app/javascript/src/features/file-browser/hooks/use-pagination.tsx
+++ b/app/javascript/src/features/file-browser/hooks/use-pagination.tsx
@@ -1,9 +1,8 @@
 import { useSearchParams } from 'react-router';
 import { PaginationState, Updater } from '@tanstack/react-table';
+import { DEFAULT_PAGE_SIZE } from '@/components/ui/table-builder/table-builder';
 
-const PAGE_SIZE = 50;
-
-export const usePagination = () => {
+export const usePagination = (pageSize = DEFAULT_PAGE_SIZE) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const pageFromUrl = parseInt(searchParams.get('page') ?? '1', 10);
@@ -11,7 +10,7 @@ export const usePagination = () => {
 
   const pagination: PaginationState = {
     pageIndex,
-    pageSize: PAGE_SIZE,
+    pageSize,
   };
 
   // TanStack Table calls onPaginationChange with either a new PaginationState
@@ -24,19 +23,16 @@ export const usePagination = () => {
     // pushing empty history entries on every data load.
     if (newState.pageIndex === pageIndex) return;
 
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        // Store 1-based page in URL; don't include the param on page 1 for a cleaner URL
-        if (newState.pageIndex <= 0) {
-          next.delete('page');
-        } else {
-          next.set('page', (newState.pageIndex + 1).toString());
-        }
-        return next;
-      },
-      { replace: true },
-    );
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      // Store 1-based page in URL; don't include the param on page 1 for a cleaner URL
+      if (newState.pageIndex <= 0) {
+        next.delete('page');
+      } else {
+        next.set('page', (newState.pageIndex + 1).toString());
+      }
+      return next;
+    });
   };
 
   return { pagination, onPaginationChange };

--- a/app/javascript/src/testing/data-generators.ts
+++ b/app/javascript/src/testing/data-generators.ts
@@ -22,6 +22,12 @@ export const buildS3Object = (overrides?: Partial<S3Object>): S3Object => ({
   ...overrides,
 });
 
+// Build an array of S3 objects with sequentially numbered names (object-000.txt, object-001.txt, etc.)
+export const buildS3Objects = (count: number): S3Object[] =>
+  Array.from({ length: count }, (_, i) =>
+    buildS3Object({ key: `object-${String(i).padStart(3, '0')}.txt` }),
+  );
+
 // Build a full bucket-contents API response
 export const buildBucketContents = (
   overrides?: Partial<BucketContentsResponse>,

--- a/app/javascript/src/testing/test-utils.tsx
+++ b/app/javascript/src/testing/test-utils.tsx
@@ -14,6 +14,7 @@ export {
   buildBucket,
   buildObjectDetails,
   buildS3Object,
+  buildS3Objects,
   buildBucketContents,
 } from './data-generators';
 export { mockApi } from './mock-api';
@@ -28,17 +29,13 @@ const createTestQueryClient = () =>
     },
   });
 
-/*
-  renderApp - renders a component inside a QueryClient + MemoryRouter
-*/
-
 interface RenderAppOptions {
   url?: string;
   path?: string;
   [key: string]: unknown;
 }
 
-export const renderApp = async (
+const buildRoutedRender = (
   ui: React.ReactElement,
   {
     url = '/', // simulated browser location to navigate to (e.g. '/users/janedoe/edit')
@@ -55,13 +52,30 @@ export const renderApp = async (
     initialIndex: isRoot ? 0 : 1,
   });
 
-  return rtlRender(
+  const result = rtlRender(
     <QueryClientProvider client={queryClient}>
       <Notifications />
       <RouterProvider router={router} />
     </QueryClientProvider>,
     renderOptions,
   );
+
+  return { result, router };
+};
+
+// Default helper - renders a component inside a QueryClient + MemoryRouter
+export const renderApp = async (ui: React.ReactElement, options: RenderAppOptions = {}) => {
+  const { result } = buildRoutedRender(ui, options);
+  return result;
+};
+
+// App + router - use for testing URLs (eg. navigation logic that modifies `?page=N` param).
+export const renderAppWithRouter = async (
+  ui: React.ReactElement,
+  options: RenderAppOptions = {},
+) => {
+  const { result, router } = buildRoutedRender(ui, options);
+  return { ...result, router };
 };
 
 export * from '@testing-library/react';


### PR DESCRIPTION
# Ticket [DSM-172](https://columbiauniversitylibraries.atlassian.net/browse/DSM-172)

## Bugs
This PR fixes the following pagination-related bugs:

1. When navigating to the second results page and then pressing the back button, the router skipped going to the first page (also going to the next page didn't create an entry in the browser history, which meant it was not possible to go back to the previous page within the same bucket)
2. When going directly to a link with a pagination param (like `?page=7`), the page param was removed once the data was done fetching

These were fixed by:
-  removing `{ replace: true }` so the browser history doesn't get overwritten
- setting `autoResetPageIndex` to false for client-side pagination (which is what we use). By default, TanStack Table sets it to true, which results in stripping the `?page=` param and navigating to the first page, no matter what page was originally passed in.

3. Buckets or directories with 0 results show "Showing 1-0 of 0"
Added handling of no data and modified the page count to start at 1.

## Tests
Added tests for common pagination scenarios to verify that:
- `?page=` param is preserved and the right data is being displayed
- prev/next/first/last navigation buttons work as expected
- navigation buttons are disabled if there is only one page

For those tests to work properly, I added a new `renderAppWithRouter` test utility function, which is similar to the existing `renderApp` but includes the router as well for url/location verification.

I also made an additional change to allow for specifying a different page size. The default value is still 50 but having more flexibility makes the pagination tests simpler (instead of creating 50+ objects we can test pagination with smaller arrays). This also means that in the future, we could easily add an option for the users to specify their own page size.